### PR TITLE
[setting] cors 설정 및 헤더 설정 추가

### DIFF
--- a/src/main/java/kr/composite/api/global/ui/CorsConfig.java
+++ b/src/main/java/kr/composite/api/global/ui/CorsConfig.java
@@ -24,6 +24,7 @@ public class CorsConfig implements WebMvcConfigurer {
                 .allowedMethods(ALLOWED_METHODS)
                 .allowedHeaders("*")
                 .allowCredentials(true)
+                .exposedHeaders("Authorization")
                 .maxAge(3600);
     }
 }

--- a/src/main/java/kr/composite/api/global/ui/SwaggerConfig.java
+++ b/src/main/java/kr/composite/api/global/ui/SwaggerConfig.java
@@ -3,8 +3,11 @@ package kr.composite.api.global.ui;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -12,6 +15,7 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
+                .servers(List.of(new Server().url("/")))
                 .components(new Components())
                 .info(apiInfo());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,9 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         globally_quoted_identifiers: true
 
+server:
+  forward-headers-strategy: framework
+
 authentication:
   jwt:
     expiration: ${JWT_EXPIRATION}


### PR DESCRIPTION
## Issue Number
<!--#이슈번호-->

## 작업 내용
<!-- 변경 사항 -->
기존 swagger에서 https -> http 요청을 보내고 있어서 문제가 생겼습니다.
프록시가 넘겨준 origin을 그대로 따르는 방식으로 리팩터링하였습니다.

기존 헤더 응답에 Authorizatio을 열고 있지 않아 클라이언트에서 해당 헤더를 확인할 수 없었던 부분을 수정했습니다.