### PR TITLE
[refactor] lessonId를 얻을 수 없던 문제 수정

### DIFF
--- a/src/main/java/kr/composite/api/lesson/application/AuthenticateLessonResult.java
+++ b/src/main/java/kr/composite/api/lesson/application/AuthenticateLessonResult.java
@@ -1,0 +1,8 @@
+package kr.composite.api.lesson.application;
+
+public record AuthenticateLessonResult(
+        String token,
+        Long lessonId
+) {
+
+}

--- a/src/main/java/kr/composite/api/lesson/application/LessonService.java
+++ b/src/main/java/kr/composite/api/lesson/application/LessonService.java
@@ -58,7 +58,7 @@ public class LessonService {
     private final CredentialCodec credentialCodec;
 
     @Transactional
-    public void joinStudent(String lessonCodeValue, User user, JoinLessonRequest request) {
+    public Long joinStudent(String lessonCodeValue, User user, JoinLessonRequest request) {
         LessonCode lessonCode = new LessonCode(lessonCodeValue);
         Lesson lesson = lessonRepository.findByLessonCode(lessonCode)
                 .orElseThrow(() -> LessonApplicationException.cannotFindLesson());
@@ -75,6 +75,8 @@ public class LessonService {
         Student savedStudent = studentRepository.save(studentToSave);
 
         eventPublisher.publishEvent(new StudentParticipateEvent(savedStudent, lessonId));
+
+        return lessonId;
     }
 
     @Transactional
@@ -98,7 +100,7 @@ public class LessonService {
     }
 
     @Transactional(readOnly = true)
-    public String readMyLesson(FindMyLessonRequest request) {
+    public AuthenticateLessonResult readMyLesson(FindMyLessonRequest request) {
         LessonCode lessonCode = new LessonCode(request.lessonCode());
         Lesson lesson = lessonRepository.findByLessonCode(lessonCode)
                 .orElseThrow(() -> LessonApplicationException.cannotFindLesson());
@@ -110,16 +112,15 @@ public class LessonService {
                 .orElseThrow(() -> LessonApplicationException.cannotFindTeacher());
 
         CredentialPayload payload = new CredentialPayload(teacher.getUserId());
+        String token = credentialCodec.encode(payload);
 
-        return credentialCodec.encode(payload);
+        return new AuthenticateLessonResult(token, lesson.getId());
     }
 
     @Transactional(readOnly = true)
-    public GetLessonResponse readLesson(String lessonCodeValue, User user) {
-        LessonCode lessonCode = new LessonCode(lessonCodeValue);
-        Lesson lesson = lessonRepository.findByLessonCode(lessonCode)
+    public GetLessonResponse readLesson(Long lessonId, User user) {
+        Lesson lesson = lessonRepository.findById(lessonId)
                 .orElseThrow(() -> LessonApplicationException.cannotFindLesson());
-        Long lessonId = lesson.getId();
 
         Teacher teacher = teacherRepository.findByLessonId(lessonId)
                 .orElseThrow(() -> LessonApplicationException.cannotFindTeacher());
@@ -132,10 +133,9 @@ public class LessonService {
     }
 
     @Transactional(readOnly = true)
-    public GetWidgetIdsResponse readWidgetIds(String lessonCodeValue, User user) {
-        Lesson lesson = lessonRepository.findByLessonCode(new LessonCode(lessonCodeValue))
+    public GetWidgetIdsResponse readWidgetIds(Long lessonId, User user) {
+        lessonRepository.findById(lessonId)
                 .orElseThrow(LessonApplicationException::cannotFindLesson);
-        Long lessonId = lesson.getId();
 
         validateParticipant(lessonId, user.getId());
 

--- a/src/main/java/kr/composite/api/lesson/ui/LessonController.java
+++ b/src/main/java/kr/composite/api/lesson/ui/LessonController.java
@@ -1,14 +1,17 @@
 package kr.composite.api.lesson.ui;
 
 import jakarta.servlet.http.HttpServletResponse;
+import kr.composite.api.lesson.application.AuthenticateLessonResult;
 import kr.composite.api.lesson.application.LessonService;
 import kr.composite.api.lesson.ui.apiSpec.LessonApiSpec;
 import kr.composite.api.lesson.ui.dto.request.CreateLessonRequest;
 import kr.composite.api.lesson.ui.dto.request.FindMyLessonRequest;
 import kr.composite.api.lesson.ui.dto.request.JoinLessonRequest;
+import kr.composite.api.lesson.ui.dto.response.AuthenticateLessonResponse;
 import kr.composite.api.lesson.ui.dto.response.CreateLessonResponse;
 import kr.composite.api.lesson.ui.dto.response.GetLessonResponse;
 import kr.composite.api.lesson.ui.dto.response.GetWidgetIdsResponse;
+import kr.composite.api.lesson.ui.dto.response.JoinStudentResponse;
 import kr.composite.api.user.domain.User;
 import kr.composite.api.user.ui.CredentialTranslator;
 import kr.composite.api.user.ui.requestuser.RequestUser;
@@ -30,14 +33,14 @@ public class LessonController implements LessonApiSpec {
 
     @Override
     @PostMapping("/lessons/{lessonCode}/students")
-    public ResponseEntity<Void> joinStudent(
+    public ResponseEntity<JoinStudentResponse> joinStudent(
             @RequestUser User user,
             @PathVariable("lessonCode") String lessonCode,
             @RequestBody JoinLessonRequest request
     ) {
-        lessonService.joinStudent(lessonCode, user, request);
+        Long lessonId = lessonService.joinStudent(lessonCode, user, request);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(JoinStudentResponse.from(lessonId));
     }
 
     @Override
@@ -53,34 +56,34 @@ public class LessonController implements LessonApiSpec {
 
     @Override
     @PostMapping("/lessons/authentications")
-    public ResponseEntity<Void> authenticateLesson(
+    public ResponseEntity<AuthenticateLessonResponse> authenticateLesson(
             HttpServletResponse response,
             @RequestBody FindMyLessonRequest request
     ) {
-        String token = lessonService.readMyLesson(request);
-        credentialTranslator.inject(response, token);
+        AuthenticateLessonResult result = lessonService.readMyLesson(request);
+        credentialTranslator.inject(response, result.token());
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(AuthenticateLessonResponse.from(result.lessonId()));
     }
 
     @Override
-    @GetMapping("/lessons/{lessonCode}")
+    @GetMapping("/lessons/{lessonId}")
     public ResponseEntity<GetLessonResponse> getLesson(
-            @PathVariable("lessonCode") String lessonCode,
+            @PathVariable("lessonId") Long lessonId,
             @RequestUser User user
     ) {
-        GetLessonResponse getLessonResponse = lessonService.readLesson(lessonCode, user);
+        GetLessonResponse getLessonResponse = lessonService.readLesson(lessonId, user);
 
         return ResponseEntity.ok().body(getLessonResponse);
     }
 
     @Override
-    @GetMapping("/lessons/{lessonCode}/widgets")
+    @GetMapping("/lessons/{lessonId}/widgets")
     public ResponseEntity<GetWidgetIdsResponse> getWidgetIds(
-            @PathVariable("lessonCode") String lessonCode,
+            @PathVariable("lessonId") Long lessonId,
             @RequestUser User user
     ) {
-        GetWidgetIdsResponse response = lessonService.readWidgetIds(lessonCode, user);
+        GetWidgetIdsResponse response = lessonService.readWidgetIds(lessonId, user);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/kr/composite/api/lesson/ui/apiSpec/LessonApiSpec.java
+++ b/src/main/java/kr/composite/api/lesson/ui/apiSpec/LessonApiSpec.java
@@ -7,9 +7,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import kr.composite.api.lesson.ui.dto.request.CreateLessonRequest;
 import kr.composite.api.lesson.ui.dto.request.FindMyLessonRequest;
 import kr.composite.api.lesson.ui.dto.request.JoinLessonRequest;
+import kr.composite.api.lesson.ui.dto.response.AuthenticateLessonResponse;
 import kr.composite.api.lesson.ui.dto.response.CreateLessonResponse;
 import kr.composite.api.lesson.ui.dto.response.GetLessonResponse;
 import kr.composite.api.lesson.ui.dto.response.GetWidgetIdsResponse;
+import kr.composite.api.lesson.ui.dto.response.JoinStudentResponse;
 import kr.composite.api.user.domain.User;
 import org.springframework.http.ResponseEntity;
 
@@ -17,7 +19,7 @@ import org.springframework.http.ResponseEntity;
 public interface LessonApiSpec {
 
     @Operation(summary = "학생 참여", description = "수업에 학생으로 참여합니다.")
-    ResponseEntity<Void> joinStudent(
+    ResponseEntity<JoinStudentResponse> joinStudent(
             User user,
             @Parameter(description = "수업 코드", example = "ABCD12") String lessonCode,
             JoinLessonRequest request
@@ -30,20 +32,20 @@ public interface LessonApiSpec {
     );
 
     @Operation(summary = "내 수업 인증", description = "수업자 자신이 만든 수업을 인증합니다.")
-    ResponseEntity<Void> authenticateLesson(
+    ResponseEntity<AuthenticateLessonResponse> authenticateLesson(
             HttpServletResponse response,
             FindMyLessonRequest request
     );
 
     @Operation(summary = "수업 조회", description = "수업 정보를 조회합니다.")
     ResponseEntity<GetLessonResponse> getLesson(
-            @Parameter(description = "수업 코드", example = "ABCD12") String lessonCode,
+            @Parameter(description = "수업 ID", example = "1") Long lessonId,
             User user
     );
 
     @Operation(summary = "수업 위젯 ID 조회", description = "해당 수업의 모든 위젯들을 타입별 고유 ID(memoWidgetId 등)로 그룹화하여 조회합니다.")
     ResponseEntity<GetWidgetIdsResponse> getWidgetIds(
-            @Parameter(description = "수업 코드", example = "ABCD12") String lessonCode,
+            @Parameter(description = "수업 ID", example = "1") Long lessonId,
             User user
     );
 }

--- a/src/main/java/kr/composite/api/lesson/ui/dto/response/AuthenticateLessonResponse.java
+++ b/src/main/java/kr/composite/api/lesson/ui/dto/response/AuthenticateLessonResponse.java
@@ -1,0 +1,15 @@
+package kr.composite.api.lesson.ui.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "수업 인증 응답")
+public record AuthenticateLessonResponse(
+
+        @Schema(description = "수업 ID", example = "1")
+        Long lessonId
+) {
+
+    public static AuthenticateLessonResponse from(Long lessonId) {
+        return new AuthenticateLessonResponse(lessonId);
+    }
+}

--- a/src/main/java/kr/composite/api/lesson/ui/dto/response/JoinStudentResponse.java
+++ b/src/main/java/kr/composite/api/lesson/ui/dto/response/JoinStudentResponse.java
@@ -1,0 +1,15 @@
+package kr.composite.api.lesson.ui.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "학생 수업 참여 응답")
+public record JoinStudentResponse(
+
+        @Schema(description = "수업 ID", example = "1")
+        Long lessonId
+) {
+
+    public static JoinStudentResponse from(Long lessonId) {
+        return new JoinStudentResponse(lessonId);
+    }
+}

--- a/src/test/java/kr/composite/api/lesson/application/LessonServiceTest.java
+++ b/src/test/java/kr/composite/api/lesson/application/LessonServiceTest.java
@@ -1,7 +1,6 @@
 package kr.composite.api.lesson.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
@@ -84,22 +83,25 @@ class LessonServiceTest {
         final String lessonCode = "CODE123";
         CreateLessonResponse lessonResponse = lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "테스트수업", lessonCode, "pass123"));
         final Long lessonId = lessonResponse.lessonId();
-        
+
         final String studentName = "참여자이름";
         final JoinLessonRequest request = new JoinLessonRequest(studentName);
         final User studentUser = userRepository.save(new User(new UserName("학생유저")));
 
         // when
-        lessonService.joinStudent(lessonCode, studentUser, request);
+        Long returnedLessonId = lessonService.joinStudent(lessonCode, studentUser, request);
 
         // then
-        // 1. Student가 올바르게 저장되었는지 확인
+        // 1. joinStudent가 lessonId를 반환하는지 확인
+        assertThat(returnedLessonId).isEqualTo(lessonId);
+
+        // 2. Student가 올바르게 저장되었는지 확인
         Student student = studentRepository.findByLessonIdAndUserId(lessonId, studentUser.getId()).orElseThrow();
         assertThat(student.getName().getValue()).isEqualTo(studentName);
         assertThat(student.getUserId()).isEqualTo(studentUser.getId());
         assertThat(student.getLessonId()).isEqualTo(lessonId);
 
-        // 2. 이벤트가 발행되었는지 확인
+        // 3. 이벤트가 발행되었는지 확인
         assertThat(testEventListener.getEvents()).hasSize(1);
         StudentParticipateEvent event = testEventListener.getEvents().get(0);
         assertThat(event.lessonId()).isEqualTo(lessonId);
@@ -111,7 +113,7 @@ class LessonServiceTest {
         // given
         final String lessonCode = "CODE123";
         lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "테스트수업", lessonCode, "pass123"));
-        
+
         final User studentUser = userRepository.save(new User(new UserName("학생유저")));
         lessonService.joinStudent(lessonCode, studentUser, new JoinLessonRequest("첫번째참여"));
 
@@ -128,7 +130,7 @@ class LessonServiceTest {
         final String lessonCode = "CODE123";
         CreateLessonResponse lessonResponse = lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "테스트수업", lessonCode, "pass123"));
         final Long lessonId = lessonResponse.lessonId();
-        
+
         final JoinLessonRequest request = new JoinLessonRequest(null); // 이름 없음
         final User studentUser = userRepository.save(new User(new UserName("학생유저")));
 
@@ -166,21 +168,25 @@ class LessonServiceTest {
         // given
         final String findLessonCode = "FIND123";
         final String password = "password123";
-        lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "조회수업", findLessonCode, password));
+        CreateLessonResponse createdLesson = lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "조회수업", findLessonCode, password));
         final FindMyLessonRequest request = new FindMyLessonRequest(findLessonCode, password);
 
-        // when & then
-        assertThatCode(() -> lessonService.readMyLesson(request)).doesNotThrowAnyException();
+        // when
+        AuthenticateLessonResult result = lessonService.readMyLesson(request);
+
+        // then
+        assertThat(result.lessonId()).isEqualTo(createdLesson.lessonId());
+        assertThat(result.token()).isNotBlank();
     }
 
     @Test
     void 수업을_정상적으로_조회한다() {
         // given
         final String lessonCode = "CODE123";
-        lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "테스트수업", lessonCode, "pass123"));
+        CreateLessonResponse createdLesson = lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "테스트수업", lessonCode, "pass123"));
 
         // when
-        var lessonResponse = lessonService.readLesson(lessonCode, savedUser);
+        var lessonResponse = lessonService.readLesson(createdLesson.lessonId(), savedUser);
 
         // then
         assertThat(lessonResponse.lessonName()).isEqualTo("테스트수업");
@@ -190,12 +196,12 @@ class LessonServiceTest {
     void 권한이_없는_수업_조회_시_예외가_발생한다() {
         // given
         final String lessonCode = "CODE123";
-        lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "테스트수업", lessonCode, "pass123"));
-        
+        CreateLessonResponse createdLesson = lessonService.createLesson(savedUser, new CreateLessonRequest("수업자", "테스트수업", lessonCode, "pass123"));
+
         User anotherUser = userRepository.save(new User(new UserName("다른유저")));
 
         // when & then
-        assertThatThrownBy(() -> lessonService.readLesson(lessonCode, anotherUser))
+        assertThatThrownBy(() -> lessonService.readLesson(createdLesson.lessonId(), anotherUser))
                 .isInstanceOf(LessonApplicationException.class)
                 .hasMessage("수업 접근 권한이 없습니다.");
     }


### PR DESCRIPTION
## Issue Number
<!--#이슈번호-->
#39 

## 작업 내용
<!-- 변경 사항 -->
1. getWidgetIds API 에서, lessonId를 통해 소통하도록 변경
2. getLesson에서 lessonId를 통해 소통하도록 변경
3. authenticateLesson, joinStudent API에서 lessonId를 반환하도록 변경